### PR TITLE
Blurbs banner

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -1,17 +1,1 @@
 cron:
-- description: weekly missed 
-  url: /missedemail
-  schedule: every tuesday 10:00
-  timezone: America/New_York
-- description: final reminder
-  url: /reminderemail?final=true
-  schedule: every monday 9:00
-  timezone: America/New_York
-- description: weekly reminder
-  url: /reminderemail
-  schedule: every friday 12:00
-  timezone: America/New_York
-- description: weekly digest
-  url: /digestemail
-  schedule: every monday 19:00
-  timezone: America/New_York

--- a/templates/base.html
+++ b/templates/base.html
@@ -49,9 +49,6 @@
       <div id="footer">
       <div class="container">
         <hr>
-        <p class="muted credit">Send your snippets to <a target="_blank"
-          href="mailto:{{site_email}}">{{site_email}}</a> by monday afternoon!
-        <a href="{{bugs_url}}">fix bugs</a>.</p>
       </div>
     </div>
 </body>

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,9 +38,6 @@
     <li><a href="/user/{{ current_user.email }}">Logged in as {{ current_user.pretty_name }}</a></li>
 
           </ul>
-          <p class="navbar-text pull-right">
-              send your snippets to <a target="_blank" href="mailto:{{site_email}}">{{site_email}}</a>
-            </p>
 
         </div><!--/.nav-collapse -->
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,12 @@
 {% block title %}Welcome{% endblock %}
 {% block body %}
     <div class="row">
+      <div class="alert alert-danger">
+          <strong>Discontinued!</strong> Blurbs is the new Snippets. <a
+           href="http://blurbs.betterment.com/">Use it instead &rarr;</a>
+          action.
+      </div>
+      
         <div class="col-md-12">
            <h1>Welcome back, <a href="/user/{{ current_user.email }}">{{ current_user.pretty_name }}</a></h1>
             New to Snippets? <a target="_blank" href="{{learn_more}}">Learn more

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,8 +10,6 @@
       
         <div class="col-md-12">
            <h1>Welcome back, <a href="/user/{{ current_user.email }}">{{ current_user.pretty_name }}</a></h1>
-            New to Snippets? <a target="_blank" href="{{learn_more}}">Learn more
-              to get started &rarr;</a><br/><br/>
 
 <!--
             Send your snippets to <a target="_blank" href="mailto:{{site_email}}">{{site_email}}</a> by monday afternoon!

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,6 @@
       <div class="alert alert-danger">
           <strong>Discontinued!</strong> Blurbs is the new Snippets. <a
            href="http://blurbs.betterment.com/">Use it instead &rarr;</a>
-          action.
       </div>
       
         <div class="col-md-12">


### PR DESCRIPTION
Preparing for the sunsetting of Blurbs. We'll keep Snippets up (for now) for historical purposes.

- Turned off crons (no more email reminders, digest, nags, etc)
- Added banner encouraging users to use Blurbs
- Removed instructions for sending in snippets
- Removed link to the wiki to learn more about Snippets

I'll deploy Monday night.